### PR TITLE
Produce MP wards layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ ATIP can display extra contextual layers:
 
 - POIs (points of interest) from OpenStreetMap, like schools and hospitals
 - the [Major Road Network](https://www.data.gov.uk/dataset/95f58bfa-13d6-4657-9d6f-020589498cfd/major-road-network)
+- Parliament constituency boundaries, from [OS Boundary-Line](https://www.ordnancesurvey.co.uk/products/boundary-line)
 
 These layers are England-wide, rather than being split into a file per area,
 because they're being used on the country-wide scheme browse page. Each layer

--- a/layers/generate_layers.py
+++ b/layers/generate_layers.py
@@ -32,7 +32,7 @@ def main():
 
     makeMRN()
 
-    makeWards()
+    makeParliamentaryConstituencies()
 
 
 # Extract `amenity={amenity}` polygons from OSM, and only keep a name attribute.
@@ -135,12 +135,12 @@ def makeMRN():
     run(["tippecanoe", f"mrn/mrn.geojson", "-o", f"mrn.pmtiles"])
 
 
-def makeWards():
+def makeParliamentaryConstituencies():
     # Remove files from any previous run
     try:
         os.remove("boundary_lines.zip")
         shutil.rmtree("boundary_lines")
-        os.remove("wards.pmtiles")
+        os.remove("parliamentary_constituencies.pmtiles")
     except:
         pass
 
@@ -162,7 +162,7 @@ def makeWards():
             "ogr2ogr",
             "-f",
             "GeoJSON",
-            "boundary_lines/wards.geojson",
+            "boundary_lines/parliamentary_constituencies.geojson",
             "-t_srs",
             "EPSG:4326",
             "boundary_lines/Data/bdline_gb.gpkg",
@@ -173,7 +173,14 @@ def makeWards():
     )
 
     # Convert to pmtiles
-    run(["tippecanoe", f"boundary_lines/wards.geojson", "-o", f"wards.pmtiles"])
+    run(
+        [
+            "tippecanoe",
+            f"boundary_lines/parliamentary_constituencies.geojson",
+            "-o",
+            f"parliamentary_constituencies.pmtiles",
+        ]
+    )
 
 
 def run(args):


### PR DESCRIPTION
https://github.com/acteng/atip/issues/285 has two asks involving wards: "MP's wards" and "district ward boundaries".

I think I've at least got the first in this PR. You can use https://protomaps.github.io/PMTiles/ to view the output, using the URL https://atip.uk/layers/v1/wards.pmtiles.

Questions:

- Do "MP wards" = parliamentary constituencies?
- Do you know a table somewhere that maps each constituency to the current MP (or better yet, contact details)? An example census code is [E14000954](https://www.ons.gov.uk/visualisations/areas/E14000954).
- From my understanding, district wards make up these constituencies. These wards change more frequently? Where should we source this data -- something like https://geoportal.statistics.gov.uk/datasets/ons::wards-may-2023-boundaries-uk-bsc/about?

# Background

Per https://www.parliament.uk/about/how/elections-and-voting/constituencies/, there are 533 parliamentary constituencies in England, with one MP each. (And the output file here has 533 areas covering England, so that's a good sign!)

I went down a rabbit hole trying to track down these boundaries. There's a recent review of these boundaries, described at https://boundarycommissionforengland.independent.gov.uk/data-and-resources/. They pointed to https://www.ordnancesurvey.co.uk/election-maps/gb/ and https://www.ordnancesurvey.co.uk/products/boundary-line for current constituencies, so that's how I wound up there. These're released under OS Open Data.

I think ONS republishes these boundaries too, based on OS Boundary Lines: https://geoportal.statistics.gov.uk/datasets/ons::wards-may-2023-boundaries-uk-bsc/about. Scripting the download straight from OS is easier than this site, and it looks like the results are the same.