### PR TITLE
Clean up the imports for OA-level census data (vehicle ownership and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ ATIP can display extra contextual layers:
 - Wards, from [OS and ONS](https://geoportal.statistics.gov.uk/datasets/ons::wards-may-2023-boundaries-uk-bgc/explore)
 - Combined authorities from [OS and ONS](https://geoportal.statistics.gov.uk/datasets/ons::combined-authorities-december-2022-boundaries-en-buc/explore)
 - Local authority districts from [OS and ONS](https://geoportal.statistics.gov.uk/datasets/ons::local-authority-districts-may-2023-boundaries-uk-buc/explore)
+- Output-area level 2021 census data
+	- Output area boundaries from [OS and ONS](https://geoportal.statistics.gov.uk/datasets/ons::output-areas-2021-boundaries-ew-bgc/explore)
+	- Population density comes from [NOMIS TS006](https://www.nomisweb.co.uk/sources/census_2021_bulk)
+	- Car/van availability comes from [NOMIS TS004](https://www.nomisweb.co.uk/output/census/2021/census2021-ts045.zip)
 
 These layers are England-wide, rather than being split into a file per area,
 because they're being used on the country-wide scheme browse page. Each layer
@@ -103,7 +107,7 @@ If you're rerunning the script for the same output, you may need to manually del
 
 You can debug a PMTiles file using <https://protomaps.github.io/PMTiles>.
 
-There's a manual step required to generate `--wards`. See the comment in the code.
+There's a manual step required to generate `--wards` and `--census_output_areas`. See the comment in the code.
 
 ### One-time cloud setup for PMTiles
 

--- a/layers/generate_layers.py
+++ b/layers/generate_layers.py
@@ -391,9 +391,7 @@ def makeCensusOutputAreas(raw_boundaries_path):
     with open(f"{tmp}/census2021-ts006-oa.csv") as f:
         for row in csv.DictReader(f):
             key = row["geography code"]
-            if key not in oa_to_data:
-                print(f"Warning: Car ownership data missing for {key}")
-                oa_to_data[key] = {}
+            # The set of OAs in both datasets match. Let a KeyError happen if not.
             oa_to_data[key]["pop_density"] = round(
                 float(
                     row[


### PR DESCRIPTION
…population density)

@cmconlan has created the first version of these two layers in `sociodemographic-layers.py`. I started work to render them in ATIP, but hit a few things easier to fix at the source:

- the coordinate system does need to be converted from EPSG 2700 to WGS84
- I found both CSV datasets with OA-level info at https://www.nomisweb.co.uk/sources/census_2021_bulk and scripted the download + unzip
- Relying on a manual step for the OA-level geojson download, instead of the arcgis scraping approach from popgetter. I think ultimately we will simulate a browser going to the page and clicking buttons to grab the GJ file, and that'll be simpler + more reliable than this dependency on the arcgis API, which seems to require a proprietary python module
- Combining the two OA-level datasets into one GeoJSON file ultimately, rather than trying to join numeric data on-the-fly in ATIP or having two copies of a huge file (with the geometry the same, and just the numeric data differing)
- Reducing the number of properties per OA plumbed along, and rounding/trimming precision to what's useful to display ultimately. I went from around 200MB pmtiles from the first round to 135MB after these optimizations, which'll help things load faster for users

I'll do similarly for the two LSOA-level datasets, after getting the frontend stuff working nicely for the OA level layers