### PR TITLE
Start unit tests for cycle paths getProps, with a tool for generating…

### DIFF
--- a/layers/cycle_paths_tests.py
+++ b/layers/cycle_paths_tests.py
@@ -1,0 +1,47 @@
+import cycle_paths
+import unittest
+
+
+class TestGetProps(unittest.TestCase):
+    def test_getProps(self):
+        # You can generate entries using ../osm_unit_test_tool.html. The output
+        # is [kind, direction, width]. You can manually remove very irrelevant
+        # tags (like name) at your own discretion
+        for testCase in [
+            {
+                "id": "29063778",
+                "tags": ["highway=cycleway", "oneway=yes", "sidewalk=left"],
+                "output": ["track", "one-way", "unknown"],
+            },
+            {
+                "id": "256017834",
+                "tags": [
+                    "bicycle=designated",
+                    "foot=designated",
+                    "highway=cycleway",
+                    "segregated=yes",
+                ],
+                "output": ["shared_use_segregated", "unknown", "unknown"],
+            },
+        ]:
+            tags = {}
+            for tag in testCase["tags"]:
+                key, value = tag.split("=")
+                tags[key] = value
+            tags["@id"] = testCase["id"]
+
+            actualResult = cycle_paths.getProps(tags)
+
+            kind, direction, width = testCase["output"]
+            expectedResult = {
+                "kind": kind,
+                "direction": direction,
+                "width": width,
+                "osm_id": testCase["id"],
+            }
+
+            self.assertEqual(actualResult, expectedResult)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/osm_unit_test_tool.html
+++ b/osm_unit_test_tool.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>OpenStreetMap Unit Test tool</title>
+    <script>
+      async function generate() {
+        document.getElementById("output").value = "";
+
+        let wayID = document.getElementById("wayID").value;
+        let url = `https://api.openstreetmap.org/api/0.6/way/${wayID}.json`;
+        try {
+          let resp = await fetch(url);
+          let json = await resp.json();
+          let tags = json.elements[0].tags;
+
+          // Remove tags likely to not influence the output at all
+          delete tags["name"];
+          let tagsArray = Object.entries(tags).map(([k, v]) => `${k}=${v}`);
+
+          let output = {
+            id: wayID,
+            tags: tagsArray,
+            output: ["kind", "direction", "width"],
+          };
+          document.getElementById("output").value = JSON.stringify(
+            output,
+            null,
+            2
+          );
+        } catch (err) {
+          document.getElementById("output").value = `Error: ${err}`;
+        }
+      }
+
+      function copy() {
+        navigator.clipboard.writeText(document.getElementById("output").value);
+      }
+    </script>
+  </head>
+  <body>
+    <h1>OpenStreetMap Unit Test tool</h1>
+    <label for="wayID">Enter OpenStreetMap Way ID:</label>
+    <input type="text" id="wayID" />
+    <button onclick="generate()">Generate</button>
+    <br />
+
+    <h2>Output:</h2>
+    <button onclick="copy()">Copy</button>
+    <br />
+    <textarea id="output" rows="10" cols="100" readonly></textarea>
+  </body>
+</html>


### PR DESCRIPTION
… the input. #29

There are a bunch of classification problems, and unit tests would be fantastic to have before working on them. This PR just lays the groundwork -- actually adding more tests later. The little HTML helper page looks like this:
![Screenshot from 2023-08-21 16-21-25](https://github.com/acteng/atip-data-prep/assets/1664407/adb2462e-7b39-4526-b688-c605cf11718f)

Also we can use this same approach (unit tests with OSM tag input, and some kind of output) for different types of output, like LTS (https://github.com/dabreegster/routing-engines/issues/7)