### PR TITLE
Regenerate route snapper files, handling multipolygons now

### DIFF
--- a/geojson_to_osmium_extracts.py
+++ b/geojson_to_osmium_extracts.py
@@ -42,15 +42,6 @@ def main():
             # both (like Portsmouth), so include the level in the namespace.
             name = feature["properties"]["level"] + "_" + feature["properties"]["name"]
 
-            # TODO Fix upstream! All cases were checked right now and only using the first is OK.
-            if feature["geometry"]["type"] == "MultiPolygon":
-                print(
-                    f"{name} is a MultiPolygon. Arbitrarily using the first Polygon only.")
-                feature["geometry"]["type"] = "Polygon"
-                feature["geometry"]["coordinates"] = feature["geometry"]["coordinates"][0]
-            if feature["geometry"]["type"] != "Polygon":
-                raise Exception(f"{name} isn't a Polygon")
-
             with open(f"{name}.geojson", "w") as f:
                 f.write(json.dumps(feature))
             config["extracts"].append(


### PR DESCRIPTION
Regenerated the route snapper files for scheme sketcher, using fresh OSM data and incorporating [recent changes](https://github.com/dabreegster/route_snapper/blob/main/CHANGES.md) in route snapper -- namely a binary format change and handling multipolygon boundaries now (like the Isles of Scilly). I've tested these work e2e as expected in the route-snapper side. I'll update the frontend to use this as part of https://github.com/acteng/atip/pull/515, to remove a version override hack.