### PR TITLE
Add crossing_ref=parallel as equivalent to crossing_ref=tiger

### DIFF
--- a/crossings/src/main.rs
+++ b/crossings/src/main.rs
@@ -101,6 +101,7 @@ fn classify(tags: &Tags) -> Option<Crossing> {
         return match x.as_str() {
             "zebra" => Some(Crossing::Zebra),
             "tiger" => Some(Crossing::Parallel),
+            "parallel" => Some(Crossing::Parallel),
             "pelican" => Some(Crossing::Pelican),
             "puffin" => Some(Crossing::Puffin),
             "toucan" => Some(Crossing::Toucan),


### PR DESCRIPTION
Although crossing_ref=parallel isn't completely documented in the OSM wiki and hasn't formally bee accepted as a replacement for crossing_ref=tiger, it is in use and over twice as common (see https://taginfo.openstreetmap.org.uk/keys/crossing_ref#values ).